### PR TITLE
Update the filename in the unzip command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Download airpress-master.zip and unzip.
 
 ```
 wget https://github.com/Basicbydesign/airpress/archive/refs/heads/master.zip
-unzip -o airpress-master.zip
+unzip -o master.zip
 ```
 
 ## Support


### PR DESCRIPTION
The downloaded filename is master.zip but the documentation showed it in the unzip command as airpress-master.zip so the two solutions were to either change the name of the file in the unzip command, or change the wget command to: wget -O airpress-master.zip https://github.com/Basicbydesign/airpress/archive/refs/heads/master.zip